### PR TITLE
Add slash to the end of the validation url

### DIFF
--- a/src/vahti.rs
+++ b/src/vahti.rs
@@ -91,7 +91,7 @@ fn vahti_to_api(vahti: &str) -> String {
 }
 
 pub async fn is_valid_url(url: &str) -> bool {
-    if !url.starts_with("https://www.tori.fi") {
+    if !url.starts_with("https://www.tori.fi/") {
         return false;
     }
     if !url.contains('?') {


### PR DESCRIPTION
This will prevent a user from using a url such as `https://www.tori.fi.localhost/?`. 

Currently if a user used that example url, it wouldn't be a vulnerability. However, if in the future the url was used as-is without any sanitization (not sure _why_ that would happen, but never say never), then it could create a vulnerability such as [SSRF](https://en.wikipedia.org/wiki/Server-side_request_forgery).