### PR TITLE
More descriptive wordings about the search page

### DIFF
--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -99,7 +99,7 @@ pub async fn handle_interaction(ctx: Context, interaction: Interaction) {
                     .iter()
                     .find(|b| {
                         if let ActionRowComponent::Button(bb) = b {
-                            if bb.label.as_ref().unwrap() == "Hakulinkki" {
+                            if bb.label.as_ref().unwrap() == "Avaa hakusivu" {
                                 url = bb.url.as_ref().unwrap().clone();
                                 return true;
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ impl EventHandler for Handler {
                         .create_option(|option| {
                             option
                                 .name("url")
-                                .description("Hakulinkki")
+                                .description("Hakusivun linkki")
                                 .required(true)
                                 .kind(ApplicationCommandOptionType::String)
                         })
@@ -79,7 +79,7 @@ impl EventHandler for Handler {
                         .create_option(|option| {
                             option
                                 .name("url")
-                                .description("Hakulinkki")
+                                .description("Hakusivun linkki")
                                 .required(true)
                                 .kind(ApplicationCommandOptionType::String)
                         })

--- a/src/vahti.rs
+++ b/src/vahti.rs
@@ -209,7 +209,7 @@ pub async fn update_vahtis(
                                         b.url(item.url.clone())
                                     });
                                     r.create_button(|b| {
-                                        b.label("Hakulinkki");
+                                        b.label("Avaa hakusivu");
                                         b.style(ButtonStyle::Link);
                                         b.url(&url)
                                     });


### PR DESCRIPTION
I propose the following changes:

Before:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/46541386/146744167-1cf4d918-4dcb-4c96-a9b5-f4fe3dd73faa.png">

After:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/46541386/146744065-8dca0435-2de5-4c1e-a0d2-fe272a97a8c2.png">


Also made the slash command argument more descriptive:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/46541386/146744340-3162561d-d5dd-456f-b70b-8886223a8d5f.png">
